### PR TITLE
Fixed bcryptnim compilation on Apple OS X.

### DIFF
--- a/bcrypt.nimble
+++ b/bcrypt.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "bcrypt"
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Jason Livesay"
 description   = "Wraps the bcrypt (blowfish) library for creating encrypted hashes (useful for passwords)"
 license       = "BSD"

--- a/crypt-blowfish.c
+++ b/crypt-blowfish.c
@@ -73,7 +73,11 @@
 #include <string.h>
 #include <pwd.h>
 #include "blowfish.h"
+#ifdef __APPLE__
+#include <unistd.h>
+#else
 #include "crypt.h"
+#endif
 
 /* This implementation is adaptable to current computing power.
  * You can have up to 2^31 rounds which should be enough for some


### PR DESCRIPTION
While trying to compile nimforum on my Mac I found a problem compiling the bcryptnim library on OS X.
This is fixed by including "unistd.h" instead of "crypt.h".