### PR TITLE
fix: add arc4random() shim for musl libc compatibility

### DIFF
--- a/bcrypt/crypt-blowfish.c
+++ b/bcrypt/crypt-blowfish.c
@@ -79,6 +79,35 @@
 #include "crypt.h"
 #endif
 
+/* Musl libc compatibility - arc4random() implementation using /dev/urandom */
+#include <fcntl.h>
+#include <unistd.h>
+
+static u_int32_t arc4random(void)
+{
+	static int fd = -1;
+	u_int32_t val;
+	ssize_t n;
+	
+	if (fd < 0) {
+		fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+		if (fd < 0) {
+			/* Fallback to less secure method if /dev/urandom unavailable */
+			return (u_int32_t)random();
+		}
+	}
+	
+	n = read(fd, &val, sizeof(val));
+	if (n != sizeof(val)) {
+		/* If read fails, close fd and try again next time */
+		close(fd);
+		fd = -1;
+		return (u_int32_t)random();
+	}
+	
+	return val;
+}
+
 /* This implementation is adaptable to current computing power.
  * You can have up to 2^31 rounds which should be enough for some
  * time to come.


### PR DESCRIPTION
musl libc does not provide arc4random(), which crypt-blowfish.c calls for salt generation. This causes a linker failure on Alpine Linux and any other musl-based system.

Add a static arc4random() implementation that reads from /dev/urandom with a fallback to random() if unavailable.

We're currently using this patch in our nim-bcrypt package in Alpine.
https://gitlab.alpinelinux.org/alpine/aports/-/blob/1b493d5c923e1529180c9623a4db89ad407b674b/testing/nim-bcrypt/musl-compat.patch