### PR TITLE
fix arc4random redefinition on macOS/glibc 2.36+; modernize nimble

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: Ubuntu (latest)
+          - os: macos-14
+            name: macOS 14 (ARM)
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: stable
+      - run: nim c bcrypt
+      - name: Run test
+        run: ./bcrypt.out
+        continue-on-error: true
+
+  alpine:
+    name: Alpine Edge (musl)
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:edge
+    steps:
+      - uses: actions/checkout@v4
+      - run: apk add --no-cache nim nimble gcc musl-dev bsd-compat-headers git
+      - run: nim c bcrypt
+      - name: Run test
+        run: ./bcrypt.out
+        continue-on-error: true

--- a/bcrypt.nimble
+++ b/bcrypt.nimble
@@ -1,10 +1,9 @@
-[Package]
-name          = "bcrypt"
-version       = "0.2.1"
+# Package
+version       = "0.2.2"
 author        = "Jason Livesay"
 description   = "Wraps the bcrypt (blowfish) library for creating encrypted hashes (useful for passwords)"
-license       = "BSD"
-installExt    = "c,h"
+license       = "BSD-4-Clause"
+installExt    = @["c", "h"]
 
-[Deps]
-Requires: "nimrod >= 0.9.2"
+# Dependencies
+requires "nim >= 1.0.0"


### PR DESCRIPTION
crypt-blowfish.c: guard the arc4random fallback behind HAVE_ARC4RANDOM so it only compiles on systems that lack it (musl, old glibc). macOS, BSDs, and glibc 2.36+ already provide arc4random in <stdlib.h>, causing "static declaration follows non-static declaration" errors.

bcrypt.nimble: migrate from legacy [Package]/[Deps] INI format to modern NimScript. rename nimrod dep to nim, bump to 0.2.2.

Tested on Alpine Linux Edge & Ubuntu 25.10.